### PR TITLE
Update git-repo-version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "git-repo-version": "0.1.1"
+    "git-repo-version": "0.2.0"
   }
 }


### PR DESCRIPTION
New feature:

For people that doesn't want's to populate the package.json of their apps, because they app is not a dependency of anyone and they just don't care, now it fallbacks to the name of the branch.

So, in absence of a version number in the package.json, it will generage something like `master.1a2b3c4d` or `use-glimmer.9f8c7a4b`. In case the commit you're in is not the head of a branch, it will generate `DETACHED_HEAD.9f8c7a4b`.

