### PR TITLE
Only register with Ember.libraries once.

### DIFF
--- a/app/initializers/app-version.js
+++ b/app/initializers/app-version.js
@@ -2,11 +2,15 @@ import config from '../config/environment';
 import Ember from 'ember';
 
 var classify = Ember.String.classify;
+var registered = false;
 
 export default {
   name: 'App Version',
   initialize: function(container, application) {
-    var appName = classify(application.toString());
-    Ember.libraries.register(appName, config.APP.version);
+    if (!registered) {
+      var appName = classify(application.toString());
+      Ember.libraries.register(appName, config.APP.version);
+      registered = true;
+    }
   }
 }


### PR DESCRIPTION
This initializer will run once for every application boot. This is fine for non-testing scenarios, but when testing each acceptance test will fire the initializer resulting in the library being reregistered many times.

When a library is re-registered the following warning is printed to the console:

```
Library "MyAppName" is already registered with Ember.
```

References:

* https://github.com/emberjs/ember.js/issues/10600
* https://github.com/ember-cli/ember-cli/issues/3478