### PR TITLE
Upgrade git-repo-version to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-  "git-repo-version": "0.2.0"
+  "git-repo-version": "0.3.0"
   }
 }


### PR DESCRIPTION
Fixes a discrepancy with SemVer 2.0 where any metadata after the version number must be separated with a `+` instead of `.`