### PR TITLE
add bower install instruction to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you add build metadata to the version, this addon will automatically append S
 
 * `git clone git@github.com:taras/ember-cli-app-version.git`
 * `npm install`
+* `bower install`
 * `ember test`
 * `ember test --server`
 


### PR DESCRIPTION
`bower install` seemed necessary when installing locally to run the tests.