### PR TITLE
Update app-version.js

### DIFF
--- a/app/components/app-version.js
+++ b/app/components/app-version.js
@@ -2,7 +2,8 @@ import AppVersionComponent from 'ember-cli-app-version/components/app-version';
 
 import config from '../config/environment';
 
-const { name, version } = config.APP;
+var name = config.APP.name;
+var version = config.APP.version;
 
 export default AppVersionComponent.extend({
   version: version,


### PR DESCRIPTION
the app/ dir of an addon must be written ES3/ES5 safe with the exception of ES6 Module syntax.

We will soon make babel mandatory which will make this a non-problem, but until then.