### PR TITLE
Upgrade to ember-cli-htmlbars ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
     "git-repo-version": "0.3.0",
-    "ember-cli-htmlbars": "0.7.9"
+    "ember-cli-htmlbars": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This indirectly uses the [new plugin API](https://github.com/ember-cli/ember-cli/issues/4562), which we'll make use of soon. (It's backwards-compatible.)