### PR TITLE
Pure Version (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ If you add build metadata to the version, this addon will automatically append S
 
 This addon provides `{{app-version}}` component that allows you to show your current app version in your app.
 
+The `{{app-version}}` includes the git commit as standard. To display only the version number;
+
+```
+{{app-version usePureVersion=true}}
+```
+
 ## Installation
 
 * ember install ember-cli-app-version

--- a/addon/components/app-version.js
+++ b/addon/components/app-version.js
@@ -3,5 +3,6 @@ import layout from '../templates/app-version';
 
 export default Ember.Component.extend({
   tagName: 'span',
-  layout: layout
+  layout: layout,
+  usePureVersion: false
 });

--- a/addon/templates/app-version.hbs
+++ b/addon/templates/app-version.hbs
@@ -1,1 +1,5 @@
+{{#if usePureVersion}}
+{{versionPure}}
+{{else}}
 {{version}}
+{{}}

--- a/addon/templates/app-version.hbs
+++ b/addon/templates/app-version.hbs
@@ -2,4 +2,4 @@
 {{versionPure}}
 {{else}}
 {{version}}
-{{}}
+{{/if}}

--- a/app/components/app-version.js
+++ b/app/components/app-version.js
@@ -7,5 +7,20 @@ var version = config.APP.version;
 
 export default AppVersionComponent.extend({
   version: version,
-  name: name
+  name: name,
+
+  versionPure: function() {
+     if (version.split('+')[0]) {
+       return version.split('+')[0];
+     }
+     return '';
+   }.property('version'),
+
+   versionGit: function() {
+     if (version.split('+')[1]) {
+       return version.split('+')[1];
+     }
+     return '';
+   }.property('version')
+
 });


### PR DESCRIPTION
Allow specification of wether to use the `pureVersion` (number) or the default behaviour. Implemented this way so as not to change the default but I think there are potentially a few ways about this. Based on work by @Schnellesadlerauge
### usage

`{{app-version usePureVersion=true}}`
### output

`0.1.0` instead of `0.1.0+<git SHA>`
### WIP

Currently **work in progress** as may want to revisit default implementation etc. Also;
- [ ] test `usePureVersion`
- [ ] allow output of just git commit SHA
- [ ] fix build
- [ ] ?
