### PR TITLE
Upgrade git-repo-version to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "git-repo-version": "0.4.0",
+    "git-repo-version": "0.4.1",
     "ember-cli-htmlbars": "^1.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Hi there 👋 

Is there any chance we could get this merged in and a 2.0.1 release? Unfortunately, there's a downstream change in an unpinned dependency that has created a blocking bug for any repository using git submodules. 

The maintainer of [git-repo-version](https://github.com/cibernox/git-repo-version/issues/14) has kindly pushed a release that pins the version of [git-repo-info](https://github.com/rwjblue/git-repo-info/issues/27) to an older version without the bug.

In Ghost we depend on ember-cli-app-version and this bug is severely impacting our ability to build our admin panel, and especially making it hard to do release builds.

Would really appreciate some help 😄 
 