### PR TITLE
Update to use Babel 6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower
+  - npm install -g bower npm
   - bower --version
   - npm install phantomjs-prebuilt
   - node_modules/phantomjs-prebuilt/bin/phantomjs --version

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "author": "Taras Mankovski <taras@embersherpa.com>",
   "license": "MIT",
@@ -29,7 +29,7 @@
     "ember-cli": "2.7.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0-beta.2",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^2.1.0",
@@ -49,7 +49,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
+    "ember-cli-babel": "^6.0.0-beta.7",
     "git-repo-version": "0.4.1",
     "ember-cli-htmlbars": "^1.0.0"
   },


### PR DESCRIPTION
As part of the work for ember-cli@2.13, all "built in" addons are being updated to use ember-cli-babel@6.

Also, bumped the minimum engine version to match ember-cli's version.

Seems reasonable to bump to 3.0.0 (due to the node version bump) for this.