### PR TITLE
Avoid errors when `config.APP` is not present.

### DIFF
--- a/app/initializers/app-version.js
+++ b/app/initializers/app-version.js
@@ -1,12 +1,11 @@
 import initializerFactory from 'ember-cli-app-version/initializer-factory';
 import config from '../config/environment';
 
-const {
-  APP: {
-    name,
-    version
-  }
-} = config;
+let name, version;
+if (config.APP) {
+  name = config.APP.name;
+  version = config.APP.version;
+}
 
 export default {
   name: 'App Version',


### PR DESCRIPTION
The code in `index.js` and `addon/index.js` specifically allows `config/environment.js` to not include `APP`, however the use of destructuring in the initializer meant that we throw an error when initializers are loaded.

I discovered this issue (due to an incomplete fixture in ember-cli's own test suite) while updating ember-cli to the latest ember-cli-qunit. 